### PR TITLE
Refresh games and navigation for better engagement

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -58,7 +58,7 @@ img{max-width:100%;display:block}
 /* Drawer */
 .drawer{position:fixed;inset:0;display:none}
 .drawer.open{display:block}
-.scrim{position:absolute;inset:0;background:rgba(0,0,0,.35)}
+.scrim{position:absolute;inset:0;background:#fff}
 .sheet{position:absolute;right:0;top:0;bottom:0;width:85vw;max-width:360px;background:#fff;box-shadow:-12px 0 24px rgba(0,0,0,.12);padding:16px 16px 24px;display:flex;flex-direction:column;gap:8px}
 .sheet-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
 .sheet-brand{display:flex;align-items:center;gap:8px}
@@ -69,9 +69,9 @@ img{max-width:100%;display:block}
 /* Mobile drawer readability */
 .drawer{ position:fixed; inset:0; display:none; z-index:80; } /* on top of hero */
 .drawer.open{ display:block; }
-.scrim{ background:rgba(0,0,0,.55); }           /* darker dimmer behind the sheet */
+.scrim{ background:#fff; }           /* solid backdrop to hide page */
 .sheet{
-  background:#fff;                               /* <-- solid white panel */
+  background:#fff;                               /* solid white panel */
   backdrop-filter:none; -webkit-backdrop-filter:none;
   border-left:1px solid var(--border);
 }

--- a/games/index.html
+++ b/games/index.html
@@ -6,38 +6,96 @@
   <title>Games • Pack 3735</title>
   <meta name="description" content="Learn by playing—Pack 3735 games." />
   <link rel="stylesheet" href="../css/styles.css" />
-  <style>
-    .topbar{position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;padding:10px 12px}
-    .logo{display:flex;gap:8px;align-items:center;text-decoration:none}
-    .logo .crest{width:20px;height:20px;display:inline-block;background:var(--blue);border-radius:4px}
-  </style>
 </head>
 <body>
-  <header class="topbar">
-    <a class="logo" href="/" aria-label="Back to Pack 3735">
-      <span class="crest">🟦</span>
-      <strong>Pack 3735</strong>
-    </a>
-  </header>
-  <main class="wrap">
-    <h1>Games</h1>
-    <p class="muted">Learn by playing.</p>
-    <div class="game-list">
-      <a class="card game-tile" href="pack-and-go/">
-        <div class="tile-body">
-          <h3>Pack &amp; Go — Six Essentials</h3>
-          <p class="muted">Tap to pack the essentials. Beat the clock, earn the patch.</p>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container nav">
+      <a href="/" class="logo" aria-label="Pack 3735 home">
+        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
+             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+        <div class="logo-text">
+          <div class="muted small">Cub Scouts • Ripon, WI</div>
+          <div class="brand">Pack 3735</div>
         </div>
-        <div class="tile-cta">Play →</div>
       </a>
-      <a class="card game-tile" href="scout-law-quiz/">
-        <div class="tile-body">
-          <h3>Scout Law Quiz</h3>
-          <p class="muted">Test your knowledge of the Scout Law.</p>
-        </div>
-        <div class="tile-cta">Play →</div>
-      </a>
+
+      <nav class="navlinks" aria-label="Primary">
+        <a href="/#about">About</a>
+        <a href="/#dens">Dens</a>
+        <a href="/#events">Events</a>
+        <a href="/#photos">Photos</a>
+        <a href="/#join">Join</a>
+        <a href="/games/">Games</a>
+        <a href="/#contact">Contact</a>
+      </nav>
+
+      <div class="navcta">
+        <a class="btn btn-primary" href="/#join">Join Now</a>
+      </div>
+
+      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
     </div>
+
+    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
+      <div class="scrim" id="closeNav" tabindex="-1"></div>
+      <div class="sheet">
+        <div class="sheet-head">
+          <div class="sheet-brand">
+            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+            <strong>Pack 3735</strong>
+          </div>
+          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
+        </div>
+        <nav class="sheet-links">
+          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
+          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
+          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
+        </nav>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section>
+      <div class="container">
+        <h1>Games</h1>
+        <p class="muted">Learn by playing.</p>
+        <a class="card game-tile" href="pack-and-go/">
+          <div class="tile-body">
+            <h3>Pack &amp; Go — Six Essentials</h3>
+            <p class="muted">Tap to pack the essentials. Beat the clock, earn the patch.</p>
+          </div>
+          <div class="tile-cta">Play →</div>
+        </a>
+        <a class="card game-tile" href="scout-law-quiz/">
+          <div class="tile-body">
+            <h3>Scout Law Quiz</h3>
+            <p class="muted">Test your knowledge of the Scout Law.</p>
+          </div>
+          <div class="tile-cta">Play →</div>
+        </a>
+      </div>
+    </section>
   </main>
+
+  <footer>
+    <div class="container foot">
+      <div>© <span id="yr"></span> Pack 3735 • Ripon, WI</div>
+      <div class="muted legal">
+        This local unit site complements official Scouting America systems. Respect youth privacy: first names only, opt-in photos,
+        no youth contact details. “Cub Scouts,” program marks, and emblems are trademarks of Scouting America; used here per local unit guidance.
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/script.js" defer></script>
 </body>
 </html>
+

--- a/games/pack-and-go/index.html
+++ b/games/pack-and-go/index.html
@@ -3,24 +3,71 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Pack & Go — Six Essentials • Pack 3735</title>
+  <title>Pack &amp; Go — Six Essentials • Pack 3735</title>
   <meta name="theme-color" content="#003F87" />
-  <meta name="description" content="Pack & Go — a fast, fun game to learn the Cub Scout Six Essentials." />
+  <meta name="description" content="Pack &amp; Go — a fast, fun game to learn the Cub Scout Six Essentials." />
+  <link rel="stylesheet" href="../../css/styles.css" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <a class="logo" href="/" aria-label="Back to Pack 3735">
-      <span class="crest">🟦</span>
-      <strong>Pack 3735</strong>
-    </a>
-    <a class="btn btn-ghost" href="../">← Back</a>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container nav">
+      <a href="/" class="logo" aria-label="Pack 3735 home">
+        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
+             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+        <div class="logo-text">
+          <div class="muted small">Cub Scouts • Ripon, WI</div>
+          <div class="brand">Pack 3735</div>
+        </div>
+      </a>
+
+      <nav class="navlinks" aria-label="Primary">
+        <a href="/#about">About</a>
+        <a href="/#dens">Dens</a>
+        <a href="/#events">Events</a>
+        <a href="/#photos">Photos</a>
+        <a href="/#join">Join</a>
+        <a href="/games/">Games</a>
+        <a href="/#contact">Contact</a>
+      </nav>
+
+      <div class="navcta">
+        <a class="btn btn-primary" href="/#join">Join Now</a>
+      </div>
+
+      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
+    </div>
+
+    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
+      <div class="scrim" id="closeNav" tabindex="-1"></div>
+      <div class="sheet">
+        <div class="sheet-head">
+          <div class="sheet-brand">
+            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+            <strong>Pack 3735</strong>
+          </div>
+          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
+        </div>
+        <nav class="sheet-links">
+          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
+          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
+          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
+        </nav>
+      </div>
+    </div>
   </header>
 
-  <main class="wrap">
+  <main id="main" class="wrap">
     <section class="hero card">
       <div>
-        <h1>Pack & Go</h1>
+        <h1>Pack &amp; Go</h1>
         <p class="kicker">Grab the <strong>Six Essentials</strong> before time runs out. Tap to pack, avoid the silly decoys.</p>
       </div>
       <div class="controls">
@@ -30,7 +77,6 @@
       </div>
     </section>
 
-    <!-- HUD -->
     <section class="hud">
       <div class="score card">
         <div><span class="label">Score</span><span id="score">0</span></div>
@@ -46,7 +92,6 @@
       </div>
     </section>
 
-    <!-- Game stage -->
     <section class="stage card">
       <div class="pack">
         <h2 class="pack-title">Backpack</h2>
@@ -58,7 +103,6 @@
     </section>
   </main>
 
-  <!-- Result / Tips modal -->
   <dialog id="modal" class="modal">
     <form method="dialog" class="modal-inner card">
       <h3 id="resultTitle">Great job!</h3>
@@ -74,7 +118,6 @@
     </form>
   </dialog>
 
-  <!-- How-to modal -->
   <dialog id="how" class="modal">
     <form method="dialog" class="modal-inner card">
       <h3>How to Play</h3>
@@ -97,6 +140,18 @@
     </form>
   </dialog>
 
+  <footer>
+    <div class="container foot">
+      <div>© <span id="yr"></span> Pack 3735 • Ripon, WI</div>
+      <div class="muted legal">
+        This local unit site complements official Scouting America systems. Respect youth privacy: first names only, opt-in photos,
+        no youth contact details. “Cub Scouts,” program marks, and emblems are trademarks of Scouting America; used here per local unit guidance.
+      </div>
+    </div>
+  </footer>
+
   <script src="./game.js" defer></script>
+  <script src="../../js/script.js" defer></script>
 </body>
 </html>
+

--- a/games/pack-and-go/styles.css
+++ b/games/pack-and-go/styles.css
@@ -1,41 +1,8 @@
-/* —— Tokens (match your site) —— */
-:root{
-  --blue:#003F87; /* Cub Scout Blue */
-  --gold:#FCD116; /* Cub Scout Gold */
-  --pale:#9AB3D5;
-  --bg:#ffffff;
-  --ink:#0b0b0b;
-  --ink-2:#4b5563;
-  --border:#e5e7eb;
-}
-*{box-sizing:border-box}
-html,body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif}
-img{max-width:100%;display:block}
-a{color:inherit;text-decoration:none}
-.muted{color:var(--ink-2)}
-.small{font-size:14px}
-
-/* —— UI chrome —— */
-.topbar{position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid var(--border);
-  display:flex;align-items:center;justify-content:space-between;padding:10px 12px}
-.logo{display:flex;gap:8px;align-items:center}
-.logo .crest{width:20px;height:20px;display:inline-block;background:var(--blue);border-radius:4px}
-
-/* —— Buttons —— */
-.btn{display:inline-block;padding:10px 14px;border-radius:16px;border:1px solid var(--border);font-weight:600}
-.btn-ghost{background:#fff}
-.btn-outline{background:#fff}
-.btn-primary{background:var(--gold);border-color:var(--gold);color:var(--blue)}
-
-/* —— Cards / layout —— */
-.card{border:1px solid var(--border);border-radius:18px;background:#fff;padding:16px}
-.card-small{border:1px solid var(--border);border-radius:12px;background:#fff;padding:10px}
 .wrap{max-width:960px;margin:0 auto;padding:16px}
 .hero{display:flex;flex-direction:column;gap:12px}
 .controls{display:flex;gap:8px;flex-wrap:wrap}
 .hud{display:grid;gap:12px;margin:12px 0;grid-template-columns:1fr}
 @media (min-width:700px){ .hud{grid-template-columns:1fr 2fr 1fr} }
-
 .score{display:flex;justify-content:space-between;gap:12px;align-items:center}
 .score .label{display:block;font-size:12px;color:var(--ink-2)}
 .timer{padding:8px;display:flex;align-items:center}
@@ -43,30 +10,22 @@ a{color:inherit;text-decoration:none}
 .patches .patch-row{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px}
 .patch{font-size:12px;padding:4px 8px;border-radius:999px;border:1px solid var(--border);background:#f8fafc}
 .patch.earned{background:var(--gold);border-color:var(--gold);color:var(--blue)}
-
 .stage{display:grid;gap:12px}
 @media (min-width:760px){ .stage{grid-template-columns:280px 1fr} }
-
 .pack-title{margin:0 0 8px}
 .slots{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:0;padding:0;list-style:none}
 .slot{height:56px;border:1px dashed var(--border);border-radius:12px;display:flex;align-items:center;justify-content:center;color:var(--ink-2)}
 .slot.filled{border-style:solid;background:#fbf8e6;color:#1f2937}
-
-.board{min-height:360px;border:1px dashed var(--border);border-radius:12px;padding:8px;display:grid;gap:8px;
-  grid-template-columns:repeat(3, 1fr)}
-@media (min-width:480px){ .board{grid-template-columns:repeat(4, 1fr)} }
-@media (min-width:900px){ .board{grid-template-columns:repeat(5, 1fr)} }
-
-.item{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;
-  padding:10px;border:1px solid var(--border);border-radius:12px;background:#fff;cursor:pointer;min-height:86px}
+.board{min-height:360px;border:1px dashed var(--border);border-radius:12px;padding:8px;display:grid;gap:8px;grid-template-columns:repeat(3,1fr)}
+@media (min-width:480px){ .board{grid-template-columns:repeat(4,1fr)} }
+@media (min-width:900px){ .board{grid-template-columns:repeat(5,1fr)} }
+.item{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;padding:10px;border:1px solid var(--border);border-radius:12px;background:#fff;cursor:pointer;min-height:86px}
 .item .emoji{font-size:28px;line-height:1}
 .item .name{font-size:12px;text-align:center}
 .item.good{box-shadow:0 0 0 2px var(--gold) inset}
 .item.bad{animation:shake .3s}
 .item[disabled]{opacity:.45;pointer-events:none}
-@keyframes shake{10%,90%{transform:translateX(-1px)} 20%,80%{transform:translateX(2px)} 30%,50%,70%{transform:translateX(-4px)} 40%,60%{transform:translateX(4px)}}
-
-/* —— Modals —— */
+@keyframes shake{10%,90%{transform:translateX(-1px)}20%,80%{transform:translateX(2px)}30%,50%,70%{transform:translateX(-4px)}40%,60%{transform:translateX(4px)}}
 .modal{border:none;border-radius:18px;padding:0}
 .modal::backdrop{background:rgba(0,0,0,.65)}
 .modal-inner{max-width:520px}
@@ -74,11 +33,9 @@ a{color:inherit;text-decoration:none}
 .grid6{display:grid;grid-template-columns:repeat(3,auto);gap:6px}
 .pill{padding:4px 8px;border-radius:999px;border:1px solid var(--border);background:#f8fafc}
 .modal-actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
-
-/* —— Focus —— */
 :focus-visible{outline:3px solid var(--gold);outline-offset:2px;border-radius:12px}
-
-/* — Reduced motion — */
 @media (prefers-reduced-motion:reduce){
   *{animation:none!important;transition:none!important}
 }
+.card{padding:16px}
+.card-small{border:1px solid var(--border);border-radius:12px;background:#fff;padding:10px}

--- a/games/scout-law-quiz/game.js
+++ b/games/scout-law-quiz/game.js
@@ -8,11 +8,31 @@ const quiz = document.getElementById('quiz');
 const questionEl = document.getElementById('question');
 const optionsEl = document.getElementById('options');
 const feedback = document.getElementById('feedback');
+const progress = document.getElementById('progress');
+
+let remaining = [];
+let score = 0;
+let qNum = 0;
 
 function nextQuestion(){
   feedback.textContent = '';
-  const correctIndex = Math.floor(Math.random() * scoutLaw.length);
-  const correct = scoutLaw[correctIndex];
+  if(remaining.length === 0){
+    questionEl.textContent = `You scored ${score} / ${scoutLaw.length}!`;
+    optionsEl.innerHTML = '';
+    const again = document.createElement('button');
+    again.textContent = 'Play Again';
+    again.className = 'btn btn-primary';
+    again.addEventListener('click', startGame);
+    optionsEl.appendChild(again);
+    progress.textContent = '';
+    return;
+  }
+
+  qNum++;
+  progress.textContent = `Question ${qNum} of ${scoutLaw.length}`;
+
+  const correctIndex = Math.floor(Math.random() * remaining.length);
+  const correct = remaining.splice(correctIndex,1)[0];
   questionEl.textContent = 'Which of these is a point of the Scout Law?';
   const opts = new Set([correct]);
   while(opts.size < 4){
@@ -30,16 +50,23 @@ function nextQuestion(){
 }
 
 function select(choice, correct){
+  Array.from(optionsEl.children).forEach(btn => btn.disabled = true);
   if(choice === correct){
     feedback.textContent = 'Correct!';
+    score++;
   }else{
     feedback.textContent = `Oops! It\'s ${correct}.`;
   }
   setTimeout(nextQuestion, 1000);
 }
 
-startBtn.addEventListener('click', () => {
+function startGame(){
   startBtn.style.display = 'none';
   quiz.hidden = false;
+  remaining = [...scoutLaw];
+  score = 0;
+  qNum = 0;
   nextQuestion();
-});
+}
+
+startBtn.addEventListener('click', startGame);

--- a/games/scout-law-quiz/index.html
+++ b/games/scout-law-quiz/index.html
@@ -6,17 +6,65 @@
   <title>Scout Law Quiz • Pack 3735</title>
   <meta name="theme-color" content="#003F87" />
   <meta name="description" content="Test your knowledge of the twelve points of the Scout Law." />
+  <link rel="stylesheet" href="../../css/styles.css" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <header class="topbar">
-    <a class="logo" href="/" aria-label="Back to Pack 3735">
-      <span class="crest">🟦</span>
-      <strong>Pack 3735</strong>
-    </a>
-    <a class="btn btn-ghost" href="../">← Back</a>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="container nav">
+      <a href="/" class="logo" aria-label="Pack 3735 home">
+        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
+             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+        <div class="logo-text">
+          <div class="muted small">Cub Scouts • Ripon, WI</div>
+          <div class="brand">Pack 3735</div>
+        </div>
+      </a>
+
+      <nav class="navlinks" aria-label="Primary">
+        <a href="/#about">About</a>
+        <a href="/#dens">Dens</a>
+        <a href="/#events">Events</a>
+        <a href="/#photos">Photos</a>
+        <a href="/#join">Join</a>
+        <a href="/games/">Games</a>
+        <a href="/#contact">Contact</a>
+      </nav>
+
+      <div class="navcta">
+        <a class="btn btn-primary" href="/#join">Join Now</a>
+      </div>
+
+      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
+    </div>
+
+    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
+      <div class="scrim" id="closeNav" tabindex="-1"></div>
+      <div class="sheet">
+        <div class="sheet-head">
+          <div class="sheet-brand">
+            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+            <strong>Pack 3735</strong>
+          </div>
+          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
+        </div>
+        <nav class="sheet-links">
+          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
+          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
+          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
+          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
+        </nav>
+      </div>
+    </div>
   </header>
-  <main class="wrap">
+
+  <main id="main" class="wrap">
     <section class="hero card">
       <div>
         <h1>Scout Law Quiz</h1>
@@ -28,8 +76,22 @@
       <h2 id="question"></h2>
       <div id="options" class="options"></div>
       <div id="feedback" class="muted"></div>
+      <div id="progress" class="muted small"></div>
     </section>
   </main>
+
+  <footer>
+    <div class="container foot">
+      <div>© <span id="yr"></span> Pack 3735 • Ripon, WI</div>
+      <div class="muted legal">
+        This local unit site complements official Scouting America systems. Respect youth privacy: first names only, opt-in photos,
+        no youth contact details. “Cub Scouts,” program marks, and emblems are trademarks of Scouting America; used here per local unit guidance.
+      </div>
+    </div>
+  </footer>
+
   <script src="./game.js" defer></script>
+  <script src="../../js/script.js" defer></script>
 </body>
 </html>
+

--- a/games/scout-law-quiz/styles.css
+++ b/games/scout-law-quiz/styles.css
@@ -1,25 +1,3 @@
-:root{
-  --blue:#003F87;
-  --gold:#FCD116;
-  --pale:#9AB3D5;
-  --bg:#ffffff;
-  --ink:#0b0b0b;
-  --ink-2:#4b5563;
-  --border:#e5e7eb;
-}
-*{box-sizing:border-box}
-html,body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,sans-serif}
-a{color:inherit;text-decoration:none}
-img{max-width:100%;display:block}
-.muted{color:var(--ink-2)}
-.small{font-size:14px}
-.topbar{position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;padding:10px 12px}
-.logo{display:flex;gap:8px;align-items:center}
-.logo .crest{width:20px;height:20px;display:inline-block;background:var(--blue);border-radius:4px}
-.btn{display:inline-block;padding:10px 14px;border-radius:16px;border:1px solid var(--border);font-weight:600}
-.btn-ghost{background:#fff}
-.btn-outline{background:#fff}
-.btn-primary{background:var(--gold);border-color:var(--gold);color:var(--blue)}
-.card{border:1px solid var(--border);border-radius:18px;background:#fff;padding:16px}
 .wrap{max-width:960px;margin:0 auto;padding:16px}
+.card{padding:16px}
 .options{display:flex;flex-direction:column;gap:8px;margin-top:12px}

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
           <a class="item" href="#events">Events <span aria-hidden="true">›</span></a>
           <a class="item" href="#photos">Photos <span aria-hidden="true">›</span></a>
           <a class="item" href="#join">Join <span aria-hidden="true">›</span></a>
+          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
           <a class="item" href="#contact">Contact <span aria-hidden="true">›</span></a>
           <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
         </nav>


### PR DESCRIPTION
## Summary
- Add Games link to mobile drawer
- Use solid white backdrop for mobile navigation
- Apply global header/footer to game pages and expand Scout Law Quiz with scoring

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check games/scout-law-quiz/game.js`
- `node --check games/pack-and-go/game.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6f9ebb548322a35a6d795dfcc787