### PR TITLE
Add quiz progress bar and social media metadata

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Games • Pack 3735</title>
   <meta name="description" content="Learn by playing—Pack 3735 games." />
+  <meta property="og:title" content="Games • Pack 3735" />
+  <meta property="og:description" content="Learn by playing—Pack 3735 games." />
+  <meta property="og:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Games • Pack 3735" />
+  <meta name="twitter:description" content="Learn by playing—Pack 3735 games." />
+  <meta name="twitter:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
   <link rel="stylesheet" href="../css/styles.css" />
 </head>
 <body>

--- a/games/scout-law-quiz/game.js
+++ b/games/scout-law-quiz/game.js
@@ -34,6 +34,10 @@ const questionEl = document.getElementById('question');
 const optionsEl = document.getElementById('options');
 const feedback = document.getElementById('feedback');
 const progress = document.getElementById('progress');
+const timer = document.getElementById('timer');
+const timerBar = document.getElementById('timerBar');
+
+const WAIT_TIME = 5000; // ms delay before next question
 
 let remaining = [];
 let score = 0;
@@ -41,6 +45,9 @@ let qNum = 0;
 
 function nextQuestion(){
   feedback.textContent = '';
+  timer.style.visibility = 'hidden';
+  timerBar.style.transition = 'none';
+  timerBar.style.width = '0%';
   if(remaining.length === 0){
     questionEl.textContent = `You scored ${score} / ${scoutLaw.length}!`;
     optionsEl.innerHTML = '';
@@ -83,7 +90,13 @@ function select(choice, correct){
   }else{
     feedback.textContent = `Oops! It's ${correct}: ${desc}`;
   }
-  setTimeout(nextQuestion, 2500);
+  timer.style.visibility = 'visible';
+  timerBar.style.transition = 'none';
+  timerBar.style.width = '0%';
+  timerBar.offsetWidth; // force reflow
+  timerBar.style.transition = `width ${WAIT_TIME}ms linear`;
+  timerBar.style.width = '100%';
+  setTimeout(nextQuestion, WAIT_TIME);
 }
 
 function startGame(){

--- a/games/scout-law-quiz/index.html
+++ b/games/scout-law-quiz/index.html
@@ -6,6 +6,14 @@
   <title>Scout Law Quiz • Pack 3735</title>
   <meta name="theme-color" content="#003F87" />
   <meta name="description" content="Test your knowledge of the twelve points of the Scout Law." />
+  <meta property="og:title" content="Scout Law Quiz • Pack 3735" />
+  <meta property="og:description" content="Test your knowledge of the twelve points of the Scout Law." />
+  <meta property="og:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Scout Law Quiz • Pack 3735" />
+  <meta name="twitter:description" content="Test your knowledge of the twelve points of the Scout Law." />
+  <meta name="twitter:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
   <link rel="stylesheet" href="../../css/styles.css" />
   <link rel="stylesheet" href="./styles.css" />
 </head>
@@ -76,6 +84,7 @@
       <h2 id="question"></h2>
       <div id="options" class="options"></div>
       <div id="feedback" class="muted"></div>
+      <div id="timer" class="timer"><div id="timerBar" class="timer-bar"></div></div>
       <div id="progress" class="muted small"></div>
     </section>
   </main>

--- a/games/scout-law-quiz/styles.css
+++ b/games/scout-law-quiz/styles.css
@@ -1,3 +1,6 @@
 .wrap{max-width:960px;margin:0 auto;padding:16px}
 .card{padding:16px}
 .options{display:flex;flex-direction:column;gap:8px;margin-top:12px}
+.options button{font-size:20px}
+.timer{height:6px;background:var(--border);margin:8px 0;border-radius:3px;overflow:hidden;visibility:hidden}
+.timer-bar{height:100%;width:0;background:var(--blue)}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Pack 3735 • Ripon, WI</title>
   <meta name="description" content="Cub Scouts Pack 3735 • Ripon, WI — Adventure. Friendship. Character." />
+  <meta property="og:title" content="Pack 3735 • Ripon, WI" />
+  <meta property="og:description" content="Cub Scouts Pack 3735 — Adventure. Friendship. Character." />
+  <meta property="og:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Pack 3735 • Ripon, WI" />
+  <meta name="twitter:description" content="Cub Scouts Pack 3735 — Adventure. Friendship. Character." />
+  <meta name="twitter:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
   <meta name="theme-color" content="#003F87" />
   <link rel="preconnect" href="https://images.unsplash.com" />
   <link rel="stylesheet" href="css/styles.css" />


### PR DESCRIPTION
## Summary
- Double the delay before moving to the next quiz question and show a progress bar for the countdown
- Enlarge quiz option buttons for easier reading
- Add Open Graph and Twitter card metadata across pages with scout logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7606e9848322957ee7dc0d8e4f7a