### PR TITLE
Restore Scout Law game and unify navigation header

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -18,57 +18,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="site-header">
-    <div class="container nav">
-      <a href="/" class="logo" aria-label="Pack 3735 home">
-        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
-             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-        <div class="logo-text">
-          <div class="muted small">Cub Scouts • Ripon, WI</div>
-          <div class="brand">Pack 3735</div>
-        </div>
-      </a>
-
-      <nav class="navlinks" aria-label="Primary">
-        <a href="/#about">About</a>
-        <a href="/#dens">Dens</a>
-        <a href="/#events">Events</a>
-        <a href="/#photos">Photos</a>
-        <a href="/#join">Join</a>
-        <a href="/games/">Games</a>
-        <a href="/#contact">Contact</a>
-      </nav>
-
-      <div class="navcta">
-        <a class="btn btn-primary" href="/#join">Join Now</a>
-      </div>
-
-      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
-    </div>
-
-    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
-      <div class="scrim" id="closeNav" tabindex="-1"></div>
-      <div class="sheet">
-        <div class="sheet-head">
-          <div class="sheet-brand">
-            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-            <strong>Pack 3735</strong>
-          </div>
-          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
-        </div>
-        <nav class="sheet-links">
-          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
-          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
-          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
-        </nav>
-      </div>
-    </div>
-  </header>
+  <div id="siteHeader"></div>
 
   <main id="main">
     <section>
@@ -86,6 +36,13 @@
           <div class="tile-body">
             <h3>Leave No Trace Ranger</h3>
             <p class="muted">Swipe choices to learn outdoor ethics.</p>
+          </div>
+          <div class="tile-cta">Play →</div>
+        </a>
+        <a class="card game-tile" href="scout-law-quiz/">
+          <div class="tile-body">
+            <h3>Scout Law Quiz</h3>
+            <p class="muted">Test your knowledge of the twelve points.</p>
           </div>
           <div class="tile-cta">Play →</div>
         </a>

--- a/games/leave-no-trace/index.html
+++ b/games/leave-no-trace/index.html
@@ -12,14 +12,11 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="game-header">
-    <a href="/games/" class="back" aria-label="Back to games">← Back</a>
-    <h1 class="title">Leave No Trace Ranger</h1>
-  </header>
+  <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
     <section class="hero card">
-      <h2>Protect the outdoors.</h2>
+      <h1>Leave No Trace Ranger</h1>
       <p class="muted">Swipe left or right to choose the Leave No Trace way.</p>
       <div class="controls">
         <button id="startBtn" class="btn btn-primary">Start</button>
@@ -66,6 +63,17 @@
 
   <div id="confetti" aria-hidden="true"></div>
 
+  <footer>
+    <div class="container foot">
+      <div>© <span id="yr"></span> Pack 3735 • Ripon, WI</div>
+      <div class="muted legal">
+        This local unit site complements official Scouting America systems. Respect youth privacy: first names only, opt-in photos,
+        no youth contact details. “Cub Scouts,” program marks, and emblems are trademarks of Scouting America; used here per local unit guidance.
+      </div>
+    </div>
+  </footer>
+
   <script src="./game.js" defer></script>
+  <script src="../../js/script.js" defer></script>
 </body>
 </html>

--- a/games/pack-and-go/index.html
+++ b/games/pack-and-go/index.html
@@ -12,57 +12,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="site-header">
-    <div class="container nav">
-      <a href="/" class="logo" aria-label="Pack 3735 home">
-        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
-             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-        <div class="logo-text">
-          <div class="muted small">Cub Scouts • Ripon, WI</div>
-          <div class="brand">Pack 3735</div>
-        </div>
-      </a>
-
-      <nav class="navlinks" aria-label="Primary">
-        <a href="/#about">About</a>
-        <a href="/#dens">Dens</a>
-        <a href="/#events">Events</a>
-        <a href="/#photos">Photos</a>
-        <a href="/#join">Join</a>
-        <a href="/games/">Games</a>
-        <a href="/#contact">Contact</a>
-      </nav>
-
-      <div class="navcta">
-        <a class="btn btn-primary" href="/#join">Join Now</a>
-      </div>
-
-      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
-    </div>
-
-    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
-      <div class="scrim" id="closeNav" tabindex="-1"></div>
-      <div class="sheet">
-        <div class="sheet-head">
-          <div class="sheet-brand">
-            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-            <strong>Pack 3735</strong>
-          </div>
-          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
-        </div>
-        <nav class="sheet-links">
-          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
-          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
-          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
-        </nav>
-      </div>
-    </div>
-  </header>
+  <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
     <section class="hero card">

--- a/games/scout-law-quiz/index.html
+++ b/games/scout-law-quiz/index.html
@@ -20,57 +20,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="site-header">
-    <div class="container nav">
-      <a href="/" class="logo" aria-label="Pack 3735 home">
-        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
-             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-        <div class="logo-text">
-          <div class="muted small">Cub Scouts • Ripon, WI</div>
-          <div class="brand">Pack 3735</div>
-        </div>
-      </a>
-
-      <nav class="navlinks" aria-label="Primary">
-        <a href="/#about">About</a>
-        <a href="/#dens">Dens</a>
-        <a href="/#events">Events</a>
-        <a href="/#photos">Photos</a>
-        <a href="/#join">Join</a>
-        <a href="/games/">Games</a>
-        <a href="/#contact">Contact</a>
-      </nav>
-
-      <div class="navcta">
-        <a class="btn btn-primary" href="/#join">Join Now</a>
-      </div>
-
-      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
-    </div>
-
-    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
-      <div class="scrim" id="closeNav" tabindex="-1"></div>
-      <div class="sheet">
-        <div class="sheet-head">
-          <div class="sheet-brand">
-            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-            <strong>Pack 3735</strong>
-          </div>
-          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
-        </div>
-        <nav class="sheet-links">
-          <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
-          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
-          <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
-          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
-        </nav>
-      </div>
-    </div>
-  </header>
+  <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
     <section class="hero card">

--- a/index.html
+++ b/index.html
@@ -20,58 +20,7 @@
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
 
-  <header class="site-header">
-    <div class="container nav">
-      <a href="#top" class="logo" aria-label="Pack 3735 home">
-        <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
-             onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-        <div class="logo-text">
-          <div class="muted small">Cub Scouts • Ripon, WI</div>
-          <div class="brand">Pack 3735</div>
-        </div>
-      </a>
-
-      <nav class="navlinks" aria-label="Primary">
-        <a href="#about">About</a>
-        <a href="#dens">Dens</a>
-        <a href="#events">Events</a>
-        <a href="#photos">Photos</a>
-        <a href="#join">Join</a>
-        <a href="/games/">Games</a>
-        <a href="#contact">Contact</a>
-      </nav>
-
-      <div class="navcta">
-        <a class="btn btn-primary" href="#join">Join Now</a>
-      </div>
-
-      <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
-    </div>
-
-    <!-- Mobile drawer -->
-    <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
-      <div class="scrim" id="closeNav" tabindex="-1"></div>
-      <div class="sheet">
-        <div class="sheet-head">
-          <div class="sheet-brand">
-            <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
-            <strong>Pack 3735</strong>
-          </div>
-          <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
-        </div>
-        <nav class="sheet-links">
-          <a class="item" href="#about">About <span aria-hidden="true">›</span></a>
-          <a class="item" href="#dens">Dens <span aria-hidden="true">›</span></a>
-          <a class="item" href="#events">Events <span aria-hidden="true">›</span></a>
-          <a class="item" href="#photos">Photos <span aria-hidden="true">›</span></a>
-          <a class="item" href="#join">Join <span aria-hidden="true">›</span></a>
-          <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
-          <a class="item" href="#contact">Contact <span aria-hidden="true">›</span></a>
-          <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
-        </nav>
-      </div>
-    </div>
-  </header>
+  <div id="siteHeader"></div>
 
   <main id="top" id="main">
     <!-- Hero -->
@@ -309,6 +258,13 @@
                 <div class="tile-badge">NEW</div>
                 <h3>Leave No Trace Ranger</h3>
                 <p class="muted">Swipe choices to learn outdoor ethics.</p>
+            </div>
+            <div class="tile-cta">Play →</div>
+            </a>
+            <a class="card game-tile" href="games/scout-law-quiz/">
+            <div class="tile-body">
+                <h3>Scout Law Quiz</h3>
+                <p class="muted">Test your knowledge of the twelve points.</p>
             </div>
             <div class="tile-cta">Play →</div>
             </a>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,51 @@
+<header class="site-header">
+  <div class="container nav">
+    <a href="/" class="logo" aria-label="Pack 3735 home">
+      <img id="crestHeader" src="/assets/cub-scout-crest.svg" alt="Cub Scouts crest"
+           onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+      <div class="logo-text">
+        <div class="muted small">Cub Scouts • Ripon, WI</div>
+        <div class="brand">Pack 3735</div>
+      </div>
+    </a>
+
+    <nav class="navlinks" aria-label="Primary">
+      <a href="/#about">About</a>
+      <a href="/#dens">Dens</a>
+      <a href="/#events">Events</a>
+      <a href="/#photos">Photos</a>
+      <a href="/#join">Join</a>
+      <a href="/games/">Games</a>
+      <a href="/#contact">Contact</a>
+    </nav>
+
+    <div class="navcta">
+      <a class="btn btn-primary" href="/#join">Join Now</a>
+    </div>
+
+    <button class="hamb" id="openNav" aria-expanded="false" aria-controls="drawer" aria-label="Open navigation">☰</button>
+  </div>
+
+  <div class="drawer" id="drawer" role="dialog" aria-modal="true" aria-label="Navigation menu">
+    <div class="scrim" id="closeNav" tabindex="-1"></div>
+    <div class="sheet">
+      <div class="sheet-head">
+        <div class="sheet-brand">
+          <img src="/assets/cub-scout-crest.svg" alt="" onerror="this.src='https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png'" />
+          <strong>Pack 3735</strong>
+        </div>
+        <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
+      </div>
+      <nav class="sheet-links">
+        <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
+        <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
+        <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
+        <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>
+        <a class="item" href="/#join">Join <span aria-hidden="true">›</span></a>
+        <a class="item" href="/games/">Games <span aria-hidden="true">›</span></a>
+        <a class="item" href="/#contact">Contact <span aria-hidden="true">›</span></a>
+        <a class="btn btn-primary" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer" style="text-decoration:none">Find Us on BeAScout ↗</a>
+      </nav>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- restore Scout Law Quiz link on home and games pages
- load a shared header fragment for consistent mobile nav
- add standard header/footer to Leave No Trace game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7fd600108322a8df7a35181b99e6