### PR TITLE
Add Memorial Day Parade photo to gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,15 +185,15 @@
       <article class="tile" data-tags="service" data-id="4">
         <figure class="media">
           <img
-            src="https://images.unsplash.com/photo-1470240731273-7821a6eeb6bd?w=480&q=60"
-            data-full="https://images.unsplash.com/photo-1470240731273-7821a6eeb6bd?w=1600&q=70"
-            alt="Community service project"
+            src="img/memorial_day.JPEG"
+            data-full="img/memorial_day.JPEG"
+            alt="Cub Scouts marching in Memorial Day Parade, Ripon, WI 2025"
             loading="lazy" decoding="async" />
         </figure>
         <div class="bar">
           <div class="meta">
             <span class="pill">Service</span>
-            <span class="muted small">Ripon</span>
+            <span class="muted small">Memorial Day Parade, Ripon, WI 2025</span>
           </div>
           <div class="actions">
             <button class="icon btn-like" aria-label="Like photo" title="Like">♥</button>


### PR DESCRIPTION
## Summary
- add Memorial Day Parade image and description to Photo Gallery
- remove default stock photo in gallery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2ee38ed08322aca1a5891cee261e