### PR TITLE
Add Scout Camp photo to gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,27 +162,7 @@
         </div>
       </article>
 
-      <article class="tile" data-tags="stem" data-id="3">
-        <figure class="media">
-          <img
-            src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=480&q=60"
-            data-full="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1600&q=70"
-            alt="Hands-on STEM activity"
-            loading="lazy" decoding="async" />
-        </figure>
-        <div class="bar">
-          <div class="meta">
-            <span class="pill">STEM</span>
-            <span class="muted small">Pack night</span>
-          </div>
-          <div class="actions">
-            <button class="icon btn-like" aria-label="Like photo" title="Like">♥</button>
-            <button class="icon btn-share" aria-label="Share photo" title="Share">↗</button>
-          </div>
-        </div>
-      </article>
-
-      <article class="tile" data-tags="service" data-id="4">
+      <article class="tile" data-tags="service" data-id="3">
         <figure class="media">
           <img
             src="img/memorial_day.JPEG"
@@ -194,6 +174,26 @@
           <div class="meta">
             <span class="pill">Service</span>
             <span class="muted small">Memorial Day Parade, Ripon, WI 2025</span>
+          </div>
+          <div class="actions">
+            <button class="icon btn-like" aria-label="Like photo" title="Like">♥</button>
+            <button class="icon btn-share" aria-label="Share photo" title="Share">↗</button>
+          </div>
+        </div>
+      </article>
+
+      <article class="tile" data-tags="campout" data-id="4">
+        <figure class="media">
+          <img
+            src="img/scout_camp.JPEG"
+            data-full="img/scout_camp.JPEG"
+            alt="Cub Scout Camp, 2025 at Camp Rokilio"
+            loading="lazy" decoding="async" />
+        </figure>
+        <div class="bar">
+          <div class="meta">
+            <span class="pill">Campout</span>
+            <span class="muted small">Cub Scout Camp, 2025 at Camp Rokilio</span>
           </div>
           <div class="actions">
             <button class="icon btn-like" aria-label="Like photo" title="Like">♥</button>


### PR DESCRIPTION
## Summary
- remove placeholder STEM tile from gallery
- add Cub Scout Camp photo with caption

## Testing
- `npx prettier -c index.html` *(fails: Code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d31a1393883228e3b8914b7c30810