### PR TITLE
Replace default hike image with Northwestern Trail photo

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,15 +145,15 @@
       <article class="tile" data-tags="hike" data-id="2">
         <figure class="media">
           <img
-            src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?w=480&q=60"
-            data-full="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?w=1600&q=70"
-            alt="Scouts hiking a wooded trail"
+            src="img/northwestern_trail.JPEG"
+            data-full="img/northwestern_trail.JPEG"
+            alt="Pack 3735 hiking the Northwestern Trail in Ripon"
             loading="lazy" decoding="async" />
         </figure>
         <div class="bar">
           <div class="meta">
             <span class="pill">Hike</span>
-            <span class="muted small">Kettle Moraine</span>
+            <span class="muted small">Northwestern Trail, Ripon</span>
           </div>
           <div class="actions">
             <button class="icon btn-like" aria-label="Like photo" title="Like">♥</button>


### PR DESCRIPTION
## Summary
- replace stock Kettle Moraine photo with Pack 3735’s Northwestern Trail hike image
- update gallery caption and alt text to reflect Ripon location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d34cf53d88322b84e9a61d57602ad