### PR TITLE
Fix popcorn banner scripts and links

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -256,7 +256,8 @@ function initNav(){
     if (c){
       if (data.deadline) c.dataset.deadline = data.deadline;
       const dl = new Date(c.dataset.deadline);
-      document.querySelector('[data-deadline-label]')?.textContent = dl.toLocaleDateString();
+      const labelEl = document.querySelector('[data-deadline-label]');
+      if (labelEl) labelEl.textContent = dl.toLocaleDateString();
       const out = c.querySelector('.pcn-countdown__time');
       const tick = ()=>{
         const now = new Date(); let s = Math.max(0, Math.floor((dl-now)/1000));
@@ -310,7 +311,7 @@ function initNav(){
     a.addEventListener('click',e=>{
       const target=document.querySelector('#popcorn');
       if(target){ e.preventDefault(); target.scrollIntoView({behavior:'smooth'}); }
-      else { a.setAttribute('href','/#popcorn'); }
+      else { e.preventDefault(); window.location.href='/#popcorn'; }
     });
   });
 })();


### PR DESCRIPTION
## Summary
- Avoid invalid assignment with optional chaining in countdown setup
- Redirect `#popcorn` links to the homepage when the section isn't present

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dec9302948322b16145265c05dd7e