### PR TITLE
style(hero): add shared background to games pages

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -27,14 +27,20 @@
   <div id="siteHeader"></div>
 
   <main id="main">
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true"></div>
+      <div class="container hero-inner">
+        <h1>Games</h1>
+        <p>Learn by playing.</p>
+      </div>
+    </section>
+
     <section>
       <div class="container">
-        <h1>Games</h1>
-        <p class="muted">Learn by playing.</p>
         <a class="card game-tile" href="pack-and-go/">
           <div class="tile-body">
-            <h3 style="color: black;">Pack &amp; Go — Six Essentials</h3>
-            <p class="muted" style="color: black;">Tap to pack the essentials. Beat the clock, earn the patch.</p>
+            <h3>Pack &amp; Go — Six Essentials</h3>
+            <p class="muted">Tap to pack the essentials. Beat the clock, earn the patch.</p>
           </div>
           <div class="tile-cta">Play →</div>
         </a>

--- a/games/leave-no-trace/index.html
+++ b/games/leave-no-trace/index.html
@@ -21,13 +21,16 @@
   <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
-    <section class="hero card">
-      <h1 style="color: black;">Leave No Trace Ranger</h1>
-      <p class="muted" style="color: black;">Swipe left or right to choose the Leave No Trace way.</p>
-      <div class="controls">
-        <button id="startBtn" class="btn btn-primary">Start</button>
-        <button id="dailyBtn" class="btn btn-outline">Today’s Deck</button>
-        <button id="soundBtn" class="btn btn-outline" aria-pressed="false">Sound: Off</button>
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true"></div>
+      <div class="container hero-inner">
+        <h1>Leave No Trace Ranger</h1>
+        <p>Swipe left or right to choose the Leave No Trace way.</p>
+        <div class="controls">
+          <button id="startBtn" class="btn btn-primary">Start</button>
+          <button id="dailyBtn" class="btn btn-outline">Today’s Deck</button>
+          <button id="soundBtn" class="btn btn-outline" aria-pressed="false">Sound: Off</button>
+        </div>
       </div>
     </section>
 

--- a/games/leave-no-trace/styles.css
+++ b/games/leave-no-trace/styles.css
@@ -2,7 +2,7 @@
 .game-header{position:sticky;top:0;z-index:40;display:flex;align-items:center;gap:12px;padding:8px 12px;background:rgba(255,255,255,.95);backdrop-filter:saturate(180%) blur(8px);border-bottom:1px solid var(--border)}
 .game-header .back{font-weight:600}
 .game-header .title{margin:0;font-size:18px}
-.hero{display:flex;flex-direction:column;gap:12px}
+.hero-inner{display:flex;flex-direction:column;gap:12px}
 .controls{display:flex;gap:8px;flex-wrap:wrap}
 .hud{display:grid;gap:12px;margin:12px 0;grid-template-columns:1fr}
 .score{display:grid;gap:4px;padding:12px}

--- a/games/pack-and-go/index.html
+++ b/games/pack-and-go/index.html
@@ -21,15 +21,16 @@
   <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
-    <section class="hero card">
-      <div>
-        <h1 style="color: black;">Pack &amp; Go</h1>
-        <p class="kicker" style="color: black;">Grab the <strong>Six Essentials</strong> before time runs out. Tap to pack, avoid the silly decoys.</p>
-      </div>
-      <div class="controls">
-        <button id="startBtn" class="btn btn-primary">Start Round</button>
-        <button id="howBtn" class="btn btn-outline">How to Play</button>
-        <button id="soundBtn" class="btn btn-outline" aria-pressed="false">Sound: Off</button>
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true"></div>
+      <div class="container hero-inner">
+        <h1>Pack &amp; Go</h1>
+        <p>Grab the <strong>Six Essentials</strong> before time runs out. Tap to pack, avoid the silly decoys.</p>
+        <div class="controls">
+          <button id="startBtn" class="btn btn-primary">Start Round</button>
+          <button id="howBtn" class="btn btn-outline">How to Play</button>
+          <button id="soundBtn" class="btn btn-outline" aria-pressed="false">Sound: Off</button>
+        </div>
       </div>
     </section>
 

--- a/games/pack-and-go/styles.css
+++ b/games/pack-and-go/styles.css
@@ -1,5 +1,5 @@
 .wrap{max-width:960px;margin:0 auto;padding:16px}
-.hero{display:flex;flex-direction:column;gap:12px}
+.hero-inner{display:flex;flex-direction:column;gap:12px}
 .controls{display:flex;gap:8px;flex-wrap:wrap}
 .hud{display:grid;gap:12px;margin:12px 0;grid-template-columns:1fr}
 @media (min-width:700px){ .hud{grid-template-columns:1fr 2fr 1fr} }

--- a/games/scout-law-quiz/index.html
+++ b/games/scout-law-quiz/index.html
@@ -29,12 +29,13 @@
   <div id="siteHeader"></div>
 
   <main id="main" class="wrap">
-    <section class="hero card">
-      <div>
-        <h1 style="color: black;">Scout Law Quiz</h1>
-        <p class="kicker" style="color: black;">Can you name the twelve points of the Scout Law?</p>
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true"></div>
+      <div class="container hero-inner">
+        <h1>Scout Law Quiz</h1>
+        <p>Can you name the twelve points of the Scout Law?</p>
+        <button id="startBtn" class="btn btn-primary">Start Quiz</button>
       </div>
-      <button id="startBtn" class="btn btn-primary">Start Quiz</button>
     </section>
     <section id="quiz" class="card" hidden>
       <h2 id="question"></h2>


### PR DESCRIPTION
## Summary
- apply site hero background to games index and game pages
- drop inline text-color overrides in game tiles and heroes
- scope game styles to `.hero-inner` for proper layout

## Testing
- ⚠️ `html5validator --root . --match "games/*.html"` (command not found)
- ⚠️ `npx --yes html-validate games/index.html games/pack-and-go/index.html games/leave-no-trace/index.html games/scout-law-quiz/index.html` (403 from npm registry)


------
https://chatgpt.com/codex/tasks/task_e_689def82e9588322b55691270b9f1c4b