### PR TITLE
feat(campout): add interactive Road America recap

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -30,6 +30,10 @@ img{max-width:100%;display:block}
 .padded{padding:24px;border-radius:24px}
 .alt{background:#f8fafc}
 
+/* Poll */
+.poll{display:flex;flex-wrap:wrap;gap:12px;margin-top:12px}
+.poll-results{list-style:none;margin:12px 0 0;padding:0}
+
 /* Focus visibility */
 :focus{outline:none}
 :focus-visible{outline:3px solid var(--gold);outline-offset:2px;border-radius:12px}

--- a/js/script.js
+++ b/js/script.js
@@ -316,3 +316,35 @@ function initNav(){
   });
 })();
 
+/* -------- Simple polls (local only) -------- */
+(()=>{
+  const polls=document.querySelectorAll('[data-poll]');
+  polls.forEach(poll=>{
+    const id=poll.dataset.poll;
+    const LS_KEY=`poll_${id}`;
+    let counts={};
+    try{counts=JSON.parse(localStorage.getItem(LS_KEY)||'{}');}catch(err){counts={};}
+    const buttons=poll.querySelectorAll('button[data-choice]');
+    const results=poll.nextElementSibling && poll.nextElementSibling.classList.contains('poll-results') ? poll.nextElementSibling : null;
+    function render(){
+      if(!results) return;
+      results.innerHTML='';
+      buttons.forEach(btn=>{
+        const c=btn.dataset.choice;
+        const li=document.createElement('li');
+        li.textContent=`${btn.textContent}: ${counts[c]||0}`;
+        results.appendChild(li);
+      });
+    }
+    render();
+    poll.addEventListener('click',e=>{
+      const btn=e.target.closest('button[data-choice]');
+      if(!btn) return;
+      const c=btn.dataset.choice;
+      counts[c]=(counts[c]||0)+1;
+      localStorage.setItem(LS_KEY,JSON.stringify(counts));
+      render();
+    });
+  });
+})();
+

--- a/road-america-campout-2025.html
+++ b/road-america-campout-2025.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Road America Campout • Pack 3735</title>
-  <meta name="description" content="Highlights from our 2025 Cub Scout campout at Road America." />
+  <meta name="description" content="Racing all day, movie night at Turn 8, a full track walk, driver autographs, and gooey s'mores capped our 2025 Road America Scout campout weekend." />
   <meta property="og:title" content="Road America Campout • Pack 3735" />
-  <meta property="og:description" content="Highlights from our 2025 Cub Scout campout at Road America." />
+  <meta property="og:description" content="Racing all day, movie night at Turn 8, a full track walk, driver autographs, and gooey s'mores capped our 2025 Road America Scout campout weekend." />
   <meta property="og:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Road America Campout • Pack 3735" />
-  <meta name="twitter:description" content="Highlights from our 2025 Cub Scout campout at Road America." />
+  <meta name="twitter:description" content="Racing all day, movie night at Turn 8, a full track walk, driver autographs, and gooey s'mores capped our 2025 Road America Scout campout weekend." />
   <meta name="twitter:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="stylesheet" href="css/styles.css" />
@@ -41,10 +41,43 @@
         <p class="kicker">We set up camp trackside and soaked in the race atmosphere.</p>
         <ul>
           <li>Watched cars roar by at the legendary 4-mile track.</li>
-          <li>Toured the paddock and met drivers.</li>
-          <li>Roasted marshmallows under the stars.</li>
+          <li>Joined a trackside movie night at Turn 8 to watch <em>Turbo</em>.</li>
+          <li>Walked the course and collected autographs from drivers.</li>
+          <li>Roasted marshmallows and made gooey s'mores under the stars.</li>
           <li>Earned a special event patch.</li>
         </ul>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <h2>Trip Timeline</h2>
+        <details>
+          <summary>Friday: Turbo at Turn 8</summary>
+          <p>After pitching tents, we hiked to Turn&nbsp;8 for an outdoor screening of <em>Turbo</em>.</p>
+        </details>
+        <details>
+          <summary>Saturday: Track Walk &amp; Autographs</summary>
+          <p>Scouts explored the 4-mile course on foot and got signatures from pro drivers in the paddock.</p>
+        </details>
+        <details>
+          <summary>Sunday: S'mores &amp; Send-off</summary>
+          <p>A sunrise campfire meant one last round of gooey s'mores before breaking camp.</p>
+        </details>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <h2>Favorite Moment?</h2>
+        <p class="kicker">Tap to vote — results stay on your device.</p>
+        <div class="poll" data-poll="ra2025-fave">
+          <button class="btn" data-choice="movie">Movie night</button>
+          <button class="btn" data-choice="walk">Track walk</button>
+          <button class="btn" data-choice="autographs">Driver autographs</button>
+          <button class="btn" data-choice="smores">S'mores</button>
+        </div>
+        <ul class="poll-results small muted"></ul>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- expand Road America campout page with movie night details, track walk, and s'mores
- add trip timeline section and local poll for favorite moments
- style poll and wire up client-side storage

## Testing
- `python - <<'PY'
from html.parser import HTMLParser
class P(HTMLParser):
    pass
P().feed(open('road-america-campout-2025.html').read())
print('parsed ok')
PY`
- `npx --yes html-validate road-america-campout-2025.html` *(fails: 403 Forbidden)*
- `npx --yes linkinator road-america-campout-2025.html --skip 'https://*'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a25a99b5ac8322aeed037f9a8c6cf4