### PR TITLE
fix(ra2025): constrain body width to container

### DIFF
--- a/road-america-campout-2025.html
+++ b/road-america-campout-2025.html
@@ -33,7 +33,7 @@
         --blue:#003F87; --gold:#FCD116; --pale:#9AB3D5;
         --ink:#0b0b0b; --ink-2:#4b5563; --border:#e5e7eb; --bg:#ffffff;
       }
-      #ra2025{font-size:16px;line-height:1.6;color:var(--ink);background:var(--bg);}
+      #ra2025{font-size:16px;line-height:1.6;color:var(--ink);background:var(--bg);max-width:var(--content-max);margin:0 auto;}
       #ra2025 h1{font-size:2.25rem;margin:0 0 1rem;}
       #ra2025 h2{font-size:1.5rem;margin:0 0 1.5rem;text-align:center;}
       #ra2025 h3{font-size:1.25rem;margin:0 0 .5rem;}


### PR DESCRIPTION
## Summary
- Limit Road America campout page body to the site's container width

## Testing
- `tidy -e road-america-campout-2025.html` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a27b3779a483228a2d46088f720d72