### PR TITLE
fix: preserve Road America gallery image aspect ratio

### DIFF
--- a/road-america-campout-2025.html
+++ b/road-america-campout-2025.html
@@ -81,7 +81,7 @@
 
       #ra2025 .lightbox{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;z-index:100;}
       #ra2025 .lightbox.open{display:flex;}
-      #ra2025 .lightbox img{max-width:90vw;max-height:90vh;border-radius:1rem;}
+      #ra2025 .lightbox img{max-width:90vw;max-height:90vh;width:auto;height:auto;border-radius:1rem;}
       #ra2025 .lightbox button{position:absolute;top:16px;right:16px;width:40px;height:40px;border:none;border-radius:50%;background:#fff;cursor:pointer;}
 
       #ra2025 .why .cols{display:grid;gap:1.5rem;margin-top:2rem;}


### PR DESCRIPTION
## Summary
- ensure lightbox images keep their original aspect ratio in Road America gallery

## Testing
- `tidy -q -e road-america-campout-2025.html` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a27fabf8e88322b5e6ccea232cdd11