### PR TITLE
feat(join): add join page with calendar and FAQ

### DIFF
--- a/join/index.html
+++ b/join/index.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Join Pack 3735 • Ripon, WI</title>
+  <meta name="description" content="Ready to try Cub Scouts? Come to a Pack 3735 meeting in Ripon, WI. We guide you through registration, uniforms, dues, and answer questions—no experience needed." />
+  <meta property="og:title" content="Join Pack 3735 • Ripon, WI" />
+  <meta property="og:description" content="Ready to try Cub Scouts? Come to a Pack 3735 meeting in Ripon, WI. We guide you through registration, uniforms, dues, and answer questions—no experience needed." />
+  <meta property="og:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Join Pack 3735 • Ripon, WI" />
+  <meta name="twitter:description" content="Ready to try Cub Scouts? Come to a Pack 3735 meeting in Ripon, WI. We guide you through registration, uniforms, dues, and answer questions—no experience needed." />
+  <meta name="twitter:image" content="https://www.scouting.org/wp-content/uploads/2021/08/cu-bs-logo.png" />
+  <meta name="theme-color" content="#003F87" />
+  <link rel="icon" href="/assets/favicon.ico" />
+  <link rel="stylesheet" href="/css/styles.css" />
+</head>
+<body>
+  <div class="popcorn-bar" role="status" aria-live="polite">
+    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
+  </div>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <div id="siteHeader"></div>
+
+  <main id="main">
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-bg" aria-hidden="true"></div>
+      <div class="container hero-inner">
+        <h1>Join Pack 3735</h1>
+        <p>Come to a pack meeting in Ripon. We will help you register and get started in Cub Scouting.</p>
+        <div class="actions">
+          <a href="#how" class="btn btn-primary">How to Join</a>
+          <a href="#faq" class="btn btn-ghost">FAQ</a>
+        </div>
+        <div class="crest"><img src="/assets/cub-scout-crest.svg" alt="" onerror="this.style.display='none'"/></div>
+      </div>
+    </section>
+
+    <!-- Why Scouting -->
+    <section id="why">
+      <div class="container">
+        <h2>Why Scouting?</h2>
+        <p class="kicker">Adventure and values in one program.</p>
+        <div class="features">
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">⚒️</div>
+            <div><strong>Builds Skills</strong><div class="muted">Outdoor fun, service, and leadership.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">🤝</div>
+            <div><strong>Friends & Family</strong><div class="muted">Parents participate; siblings often join.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">⭐</div>
+            <div><strong>Character</strong><div class="muted">We live the Scout Oath and Law.</div></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- How to Join -->
+    <section id="how" class="alt">
+      <div class="container">
+        <h2>How to Join</h2>
+        <p class="kicker">We welcome new families year-round.</p>
+        <ol class="steps list-group" role="list">
+          <li class="list-item">
+            <div class="title">Visit a pack meeting</div>
+            <div class="desc muted">Check the calendar for dates. Guests are always welcome.</div>
+          </li>
+          <li class="list-item">
+            <div class="title">Register online</div>
+            <div class="desc muted">Use BeAScout to enroll your Scout. We can help during the meeting.</div>
+          </li>
+          <li class="list-item">
+            <div class="title">Get gear</div>
+            <div class="desc muted">Your den leader will guide you on handbooks and uniforms.</div>
+          </li>
+        </ol>
+        <div class="cta-row">
+          <a class="btn btn-outline" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer">Find Us on BeAScout</a>
+          <a class="btn btn-outline" href="#calendar">See the Calendar</a>
+          <a class="btn btn-outline" href="/index.html#contact">Contact a Leader</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Calendar -->
+    <section id="calendar">
+      <div class="container">
+        <h2>Visit a Meeting</h2>
+        <p class="kicker">Pack meetings and outings appear here automatically.</p>
+        <div class="calendar card">
+          <div class="frame">
+            <iframe
+              title="Pack 3735 Google Calendar"
+              src="https://calendar.google.com/calendar/embed?src=pack3735%40gmail.com&ctz=America%2FChicago"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+              frameborder="0"
+              scrolling="no"
+              aria-label="Embedded calendar">
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq" class="alt">
+      <div class="container">
+        <h2>FAQ</h2>
+        <div class="card list-group" aria-label="Join FAQ">
+          <div class="list-item">
+            <div class="title">When and where do you meet?</div>
+            <div class="desc muted">The calendar shows pack and den meetings. Most meet Tuesday evenings in Ripon.</div>
+          </div>
+          <div class="list-item">
+            <div class="title">How much does it cost?</div>
+            <div class="desc muted">Annual dues are set by Bay-Lakes Council plus a local pack fee. We have scholarships if needed.</div>
+          </div>
+          <div class="list-item">
+            <div class="title">What about uniforms?</div>
+            <div class="desc muted">New Scouts start with a Class A shirt, neckerchief, and handbook. We have a uniform exchange for used gear.</div>
+          </div>
+          <div class="list-item">
+            <div class="title">Can siblings participate?</div>
+            <div class="desc muted">Yes. Many activities welcome the whole family.</div>
+          </div>
+          <div class="list-item">
+            <div class="title">Who leads the program?</div>
+            <div class="desc muted">Trained volunteers follow Scouting America's youth protection guidelines.</div>
+          </div>
+        </div>
+        <div class="cta-row">
+          <a class="btn btn-outline" href="https://beascout.scouting.org/" target="_blank" rel="noopener noreferrer">Join Online</a>
+          <a class="btn btn-outline" href="/index.html#contact">Email the Pack</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container foot">
+      <div>© <span id="yr"></span> Pack 3735 • Ripon, WI</div>
+      <div class="muted legal">
+        This local unit site complements official Scouting America systems. Respect youth privacy: first names only, opt-in photos,
+        no youth contact details. “Cub Scouts,” program marks, and emblems are trademarks of Scouting America; used here per local unit guidance.
+      </div>
+    </div>
+  </footer>
+
+  <script src="/js/script.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Join Pack 3735 page with hero and steps
- embed shared Google calendar for meeting info
- include FAQ and links to BeAScout and contact

## Testing
- `curl -H "Content-Type: text/html; charset=utf-8" --data-binary @join/index.html https://validator.w3.org/nu/?out=gnu` *(failure: CONNECT tunnel failed, response 403)*
- `linkchecker join/index.html` *(failure: command not found)*
- `apt-get update` *(failure: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a281c90c1c8322969ee58693859894