### PR TITLE
feat(index): add Road America weekend teaser

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -302,3 +302,9 @@ footer{border-top:1px solid var(--border)}
 .popcorn-hero::before{top:-20px;left:10%}
 .popcorn-hero::after{top:-20px;right:15%;animation-duration:15s}
 @keyframes pcn-drift{0%{transform:translateY(0) rotate(0deg)}100%{transform:translateY(120px) rotate(360deg)}}
+
+/* Road America teaser */
+#road-america .ra-teaser{display:grid;gap:1rem;padding:1rem;}
+#road-america .ra-thumb img{border-radius:12px;}
+#road-america .info{display:flex;flex-direction:column;gap:.5rem;}
+@media(min-width:640px){#road-america .ra-teaser{grid-template-columns:1fr 1fr;align-items:center;}}

--- a/index.html
+++ b/index.html
@@ -26,9 +26,10 @@
   </div>
   <a class="skip-link" href="#main">Skip to content</a>
 
+  <span id="top"></span>
   <div id="siteHeader"></div>
 
-  <main id="top" id="main">
+  <main id="main">
     <!-- Hero -->
     <section class="hero">
       <div class="hero-bg" aria-hidden="true"></div>
@@ -43,6 +44,22 @@
           <a href="#events" class="btn btn-ghost">Upcoming Events</a>
         </div>
         <div class="crest"><img src="/assets/cub-scout-crest.svg" alt="" onerror="this.style.display='none'"/></div>
+      </div>
+    </section>
+
+    <!-- Road America Scout Weekend -->
+    <section id="road-america">
+      <div class="container">
+        <div class="card ra-teaser">
+          <a href="img/road-america/road-america-group.jpg" class="ra-thumb">
+            <img src="img/road-america/road-america-group.jpg" alt="Pack 3735 group at Road America" loading="lazy" />
+          </a>
+          <div class="info">
+            <h2>Road America Scout Weekend</h2>
+            <p>Parade laps, movies under the stars, and GT racing made for a high-octane campout.</p>
+            <a class="btn btn-outline" href="road-america-campout-2025.html">See the weekend →</a>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -365,6 +382,14 @@
       </div>
     </div>
   </footer>
+
+  <div id="ra-lightbox" class="lb" hidden>
+    <div class="bg"></div>
+    <div class="stage">
+      <img alt="Pack 3735 group at Road America" loading="lazy" />
+      <button class="close" aria-label="Close">✕</button>
+    </div>
+  </div>
 
   <script src="js/script.js" defer></script>
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -316,6 +316,33 @@ function initNav(){
   });
 })();
 
+// Road America teaser lightbox
+(()=>{
+  const section=document.getElementById('road-america');
+  const thumb=section?.querySelector('.ra-thumb');
+  const lb=document.getElementById('ra-lightbox');
+  if(!section||!thumb||!lb) return;
+  const lbImg=lb.querySelector('img');
+  const btnClose=lb.querySelector('.close');
+  const bg=lb.querySelector('.bg');
+  const close=()=>{
+    lb.classList.remove('open');
+    lb.setAttribute('hidden','');
+    lbImg.removeAttribute('src');
+    thumb.focus();
+  };
+  thumb.addEventListener('click',e=>{
+    e.preventDefault();
+    lbImg.src=thumb.href;
+    lb.removeAttribute('hidden');
+    lb.classList.add('open');
+    btnClose.focus();
+  });
+  btnClose.addEventListener('click',close);
+  bg.addEventListener('click',close);
+  lb.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
+})();
+
 /* -------- Simple polls (local only) -------- */
 (()=>{
   const polls=document.querySelectorAll('[data-poll]');


### PR DESCRIPTION
## Summary
- highlight Road America Scout Weekend with group photo and recap link
- add lightbox JS and styles so photo expands full screen
- fix top anchor id duplication on index

## Testing
- `npx --yes html-validate index.html` *(fails: 403 Forbidden)*
- `npx --yes linkinator index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2871381b8832298e280ebdb49b54a