### PR TITLE
feat: expand about page and update header link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -48,13 +48,44 @@
       <div class="container hero-inner">
         <h1>About Pack 3735 - Ripon, WI</h1>
         <p>We’re a family Cub Scout pack serving Ripon-area youth in grades K–5.</p>
+        <div class="actions">
+          <a href="/join/" class="btn btn-primary">Join Pack 3735</a>
+          <a href="/events/" class="btn btn-ghost">Upcoming Events</a>
+        </div>
       </div>
     </section>
 
     <section id="who">
       <div class="container">
-        <h2>Who We Are</h2>
-        <p class="kicker">Adventure, service, and character-rooted in Ripon, WI.</p>
+        <h2>What is Cub Scouting?</h2>
+        <p class="kicker">A family program for grades K–5 that builds character, citizenship, leadership, and fitness.</p>
+        <div class="features">
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">⛺</div>
+            <div><strong>Outings & Campouts</strong><div class="muted">Ripon-area hikes, weekend campouts, STEM nights, and service.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">👨‍👩‍👧‍👦</div>
+            <div><strong>Family-Friendly</strong><div class="muted">Parents welcome at meetings and events. Siblings often join the fun.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">🛠️</div>
+            <div><strong>Skills for Life</strong><div class="muted">Badges and hands-on projects build confidence and teamwork.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">🤝</div>
+            <div><strong>Community Service</strong><div class="muted">Scouts give back through cleanups and helping neighbors.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">📷</div>
+            <div><strong>Photo-Forward</strong><div class="muted">We capture the memories—check the gallery for smiles.</div></div>
+          </div>
+          <div class="feature card">
+            <div class="icon" aria-hidden="true">📍</div>
+            <div><strong>Local Roots</strong><div class="muted">Serving Ripon, WI with strong school partnerships.</div></div>
+          </div>
+        </div>
+        <p class="more"><a href="/join/">Join Pack 3735</a> · <a href="/events/">See the Calendar</a></p>
       </div>
     </section>
 

--- a/partials/header.html
+++ b/partials/header.html
@@ -10,7 +10,7 @@
     </a>
 
     <nav class="navlinks" aria-label="Primary">
-      <a href="/#about">About</a>
+      <a href="/about/">About</a>
       <a href="/#dens">Dens</a>
       <a href="/#events">Events</a>
       <a href="/#photos">Photos</a>
@@ -38,7 +38,7 @@
         <button id="closeNavBtn" class="hamb" aria-label="Close menu">✕</button>
       </div>
       <nav class="sheet-links">
-        <a class="item" href="/#about">About <span aria-hidden="true">›</span></a>
+        <a class="item" href="/about/">About <span aria-hidden="true">›</span></a>
         <a class="item" href="/#dens">Dens <span aria-hidden="true">›</span></a>
         <a class="item" href="/#events">Events <span aria-hidden="true">›</span></a>
         <a class="item" href="/#photos">Photos <span aria-hidden="true">›</span></a>


### PR DESCRIPTION
## Summary
- enrich standalone About page with feature cards and join/events buttons
- point header navigation to About page instead of index anchor

## Testing
- `tidy -q -e about/index.html` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a347004f2083229bff988ab9e2e5a5