### PR TITLE
feat(road-america): enable group photo lightbox across site

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -102,6 +102,13 @@
       </div>
     </div>
   </footer>
+  <div id="ra-lightbox" class="lb" hidden>
+    <div class="bg"></div>
+    <div class="stage">
+      <img alt="Pack 3735 group at Road America" loading="lazy" />
+      <button class="close" aria-label="Close">✕</button>
+    </div>
+  </div>
 
   <script src="/js/script.js" defer></script>
 </body>

--- a/js/script.js
+++ b/js/script.js
@@ -318,25 +318,28 @@ function initNav(){
 
 // Road America teaser lightbox
 (()=>{
-  const section=document.getElementById('road-america');
-  const thumb=section?.querySelector('.ra-thumb');
+  const thumbs=document.querySelectorAll('.ra-thumb');
   const lb=document.getElementById('ra-lightbox');
-  if(!section||!thumb||!lb) return;
+  if(!thumbs.length||!lb) return;
   const lbImg=lb.querySelector('img');
   const btnClose=lb.querySelector('.close');
   const bg=lb.querySelector('.bg');
+  let activeThumb=null;
   const close=()=>{
     lb.classList.remove('open');
     lb.setAttribute('hidden','');
     lbImg.removeAttribute('src');
-    thumb.focus();
+    activeThumb&&activeThumb.focus();
   };
-  thumb.addEventListener('click',e=>{
-    e.preventDefault();
-    lbImg.src=thumb.href;
-    lb.removeAttribute('hidden');
-    lb.classList.add('open');
-    btnClose.focus();
+  thumbs.forEach(thumb=>{
+    thumb.addEventListener('click',e=>{
+      e.preventDefault();
+      activeThumb=thumb;
+      lbImg.src=thumb.href;
+      lb.removeAttribute('hidden');
+      lb.classList.add('open');
+      btnClose.focus();
+    });
   });
   btnClose.addEventListener('click',close);
   bg.addEventListener('click',close);

--- a/road-america-campout-2025.html
+++ b/road-america-campout-2025.html
@@ -155,7 +155,9 @@
         <p>Between amazing access and some serious Midwest weather, this was a weekend our Scouts will never forget. We threaded storms, shared snacks, met drivers, and learned sportsmanship the best way-trackside. The camping, the movie night at Turn 8, and the roar of GT cars created a perfect backdrop for new friendships.</p>
       </div>
       <figure>
-        <img src="img/road-america/road-america-group.jpg" alt="Pack 3735 group photo at Road America" loading="lazy" />
+        <a href="img/road-america/road-america-group.jpg" class="ra-thumb">
+          <img src="img/road-america/road-america-group.jpg" alt="Pack 3735 group photo at Road America" loading="lazy" />
+        </a>
         <figcaption>The Scouts gathered for a group photo during Scout Weekend.</figcaption>
       </figure>
     </section>
@@ -367,6 +369,13 @@
       </div>
     </div>
   </footer>
+  <div id="ra-lightbox" class="lb" hidden>
+    <div class="bg"></div>
+    <div class="stage">
+      <img alt="Pack 3735 group at Road America" loading="lazy" />
+      <button class="close" aria-label="Close">✕</button>
+    </div>
+  </div>
 
   <script src="js/script.js" defer></script>
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Make Road America group photo clickable with lightbox on event page, landing page, and campout detail
- Generalize lightbox script to handle multiple group photo thumbnails

## Testing
- `node --check js/script.js`
- `apt-get update && apt-get install -y tidy` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a34dabd5748322a10b4a752b7dcf8b