### PR TITLE
feat(popcorn): link to online order page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,8 +34,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/events/index.html
+++ b/events/index.html
@@ -34,8 +34,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/games/index.html
+++ b/games/index.html
@@ -21,8 +21,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/games/leave-no-trace/index.html
+++ b/games/leave-no-trace/index.html
@@ -35,8 +35,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/games/pack-and-go/index.html
+++ b/games/pack-and-go/index.html
@@ -35,8 +35,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/games/scout-law-quiz/index.html
+++ b/games/scout-law-quiz/index.html
@@ -35,8 +35,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -85,9 +85,9 @@
     <section id="popcorn" class="popcorn-hero container">
       <div class="popcorn-hero__inner">
         <h2>Popcorn = Adventures for Pack 3735</h2>
-        <p>Every bag funds campouts, Pinewood Derby kits, scholarships, and gear. Thank you for supporting Scouting in Ripon! 🙌</p>
+        <p>Order popcorn online or from a Scout. Every bag funds campouts, Pinewood Derby kits, scholarships, and gear. Thank you! 🙌</p>
         <div class="popcorn-cta">
-          <a class="btn-buy" href="#" target="_blank" rel="noopener">Buy Popcorn</a>
+          <a class="btn-buy" href="https://www.prpopcornstore.com/?sid=28H0DK" target="_blank" rel="noopener">Order Online</a>
           <a class="btn-donate" href="#" target="_blank" rel="noopener">Donate to the Pack</a>
           <a class="btn-vol" href="#" target="_blank" rel="noopener">Volunteer a Storefront Shift</a>
         </div>
@@ -102,8 +102,8 @@
           </div>
         </div>
         <ul class="popcorn-points">
+          <li>Order online 24/7 or from a Scout with a wagon.</li>
           <li>Local impact: stays with Pack 3735.</li>
-          <li>Secure online orders + in-person “wagon” sales.</li>
         </ul>
         <p class="more"><a href="/join/">Join Pack 3735</a> · <a href="/events/">See the Calendar</a></p>
       </div>

--- a/join/index.html
+++ b/join/index.html
@@ -34,8 +34,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/popcorn/index.html
+++ b/popcorn/index.html
@@ -17,8 +17,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -30,9 +30,9 @@
     <section id="popcorn" class="popcorn-hero container">
       <div class="popcorn-hero__inner">
         <h2>Popcorn = Adventures for Pack 3735</h2>
-        <p>Every bag funds campouts, Pinewood Derby kits, scholarships, and gear. Thank you for supporting Scouting in Ripon! 🙌</p>
+        <p>Order popcorn online or from a Scout. Every bag funds campouts, Pinewood Derby kits, scholarships, and gear. Thank you! 🙌</p>
         <div class="popcorn-cta">
-          <a class="btn-buy" href="#" target="_blank" rel="noopener">Buy Popcorn</a>
+          <a class="btn-buy" href="https://www.prpopcornstore.com/?sid=28H0DK" target="_blank" rel="noopener">Order Online</a>
           <a class="btn-donate" href="#" target="_blank" rel="noopener">Donate to the Pack</a>
           <a class="btn-vol" href="#volunteer" rel="noopener">Volunteer a Storefront Shift</a>
         </div>
@@ -47,8 +47,8 @@
           </div>
         </div>
         <ul class="popcorn-points">
+          <li>Order online 24/7 or from a Scout with a wagon.</li>
           <li>Local impact: stays with Pack 3735.</li>
-          <li>Secure online orders + in-person “wagon” sales.</li>
           <li>First names only & photo-opt-in to protect youth privacy.</li>
         </ul>
       </div>
@@ -60,7 +60,7 @@
       <div class="container">
         <h2>How to Buy</h2>
         <ul class="popcorn-points">
-          <li><a href="#" target="_blank" rel="noopener">Shop our online store</a> (QR code available at meetings)</li>
+          <li><a href="https://www.prpopcornstore.com/?sid=28H0DK" target="_blank" rel="noopener">Shop our online store</a> (open 24/7)</li>
           <li>Wagon sales around Ripon: weekends in September and early October.</li>
           <li>Storefront shifts at local businesses - <a href="#volunteer">sign up to help</a>.</li>
         </ul>

--- a/road-america-campout-2025.html
+++ b/road-america-campout-2025.html
@@ -33,8 +33,8 @@
 </head>
 <body>
   <div class="popcorn-bar" role="status" aria-live="polite">
-    <span>🍿 Popcorn Season is on! <strong>Order by <span data-deadline-label>Oct 12</span></strong></span>
-    <a href="#popcorn" class="popcorn-bar__btn">Buy Popcorn</a>
+    <span>🍿 Popcorn Season is on! <strong>Order online by <span data-deadline-label>Oct 12</span></strong></span>
+    <a href="https://www.prpopcornstore.com/?sid=28H0DK" class="popcorn-bar__btn" target="_blank" rel="noopener">Order Online</a>
     <button class="popcorn-bar__close" aria-label="Dismiss">×</button>
   </div>
   <a class="skip-link" href="#main">Skip to content</a>


### PR DESCRIPTION
## Summary
- link popcorn alert bar and buttons to new PR Popcorn online store
- highlight online ordering on index and popcorn pages

## Testing
- `npx html-validate about/index.html events/index.html games/index.html games/leave-no-trace/index.html games/pack-and-go/index.html games/scout-law-quiz/index.html index.html join/index.html popcorn/index.html road-america-campout-2025.html` *(fails: 403 Forbidden)*
- `pip install html5validator` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a36fe9248c8322918c61d6d5052423