### PR TITLE
fix(hero): restore popcorn background

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -91,7 +91,7 @@ img{max-width:100%;display:block}
 .hero-bg{
   position:absolute;
   inset:0;
-  background:url('/assets/popcorn_hero.png') no-repeat;
+  background:url('/assets/background_hero.png') no-repeat;
   background-size:cover;
   background-position:left center;
   z-index:0;


### PR DESCRIPTION
## Summary
- point hero background to `background_hero.png` so all hero sections show the popcorn image again

## Testing
- `tidy -q -e index.html` *(fails: command not found)*
- `curl -s -H "Content-Type: text/html; charset=utf-8" --data-binary @index.html https://validator.w3.org/nu/?out=gnu | head -n 20` *(no output due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a3df9afa208322ab01422ff0e9a148