### PR TITLE
fix: make mobile nav drawer background opaque

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -67,10 +67,10 @@ img{max-width:100%;display:block}
 }
 
 /* Drawer */
-.drawer{position:fixed;inset:0;display:none}
+.drawer{position:fixed;inset:0;display:none;background:var(--bg)}
 .drawer.open{display:block}
-.scrim{position:absolute;inset:0;background:#fff}
-.sheet{position:absolute;right:0;top:0;bottom:0;width:85vw;max-width:360px;background:#fff;box-shadow:-12px 0 24px rgba(0,0,0,.12);padding:16px 16px 24px;display:flex;flex-direction:column;gap:8px}
+.scrim{position:absolute;inset:0;background:var(--bg)}
+.sheet{position:absolute;right:0;top:0;bottom:0;width:85vw;max-width:360px;background:#fff;box-shadow:-12px 0 24px rgba(0,0,0,.12);padding:16px 16px 24px;display:flex;flex-direction:column;gap:8px;overflow-y:auto}
 .sheet-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
 .sheet-brand{display:flex;align-items:center;gap:8px}
 .sheet-brand img{width:32px;height:32px;object-fit:contain}
@@ -78,9 +78,9 @@ img{max-width:100%;display:block}
 .sheet a.item{display:flex;justify-content:space-between;align-items:center;border:1px solid var(--border);border-radius:12px;padding:12px 14px}
 
 /* Mobile drawer readability */
-.drawer{ position:fixed; inset:0; display:none; z-index:80; } /* on top of hero */
+.drawer{ position:fixed; inset:0; display:none; z-index:80; background:var(--bg); } /* on top of hero */
 .drawer.open{ display:block; }
-.scrim{ background:#fff; }           /* solid backdrop to hide page */
+.scrim{ background:var(--bg); }           /* solid backdrop to hide page */
 .sheet{
   background:#fff;                               /* solid white panel */
   backdrop-filter:none; -webkit-backdrop-filter:none;
@@ -90,6 +90,12 @@ img{max-width:100%;display:block}
   background:#fff;                               /* each row solid white */
 }
 .sheet a.item:hover{ background:#f9fafb; }
+
+body.nav-open{
+  position:fixed;
+  width:100%;
+  overflow:hidden;
+}
 
 /* Hero */
 .hero{position:relative;color:#fff}

--- a/js/script.js
+++ b/js/script.js
@@ -13,11 +13,15 @@ function initNav(){
   const closeNavBtn = $('#closeNavBtn');
   const sheetLinks = $$('.sheet a');
   let lastFocused = null;
+  let scrollY = 0;
   if (!drawer || !openNav || !closeNav || !closeNavBtn) return;
 
   function openDrawer(){
     drawer.classList.add('open');
     openNav.setAttribute('aria-expanded', 'true');
+    scrollY = window.scrollY;
+    document.body.dataset.navScroll = String(scrollY);
+    document.body.style.top = `-${scrollY}px`;
     document.body.classList.add('nav-open');
     lastFocused = document.activeElement;
     const first = $('.sheet a, .sheet button');
@@ -29,6 +33,10 @@ function initNav(){
     drawer.classList.remove('open');
     openNav.setAttribute('aria-expanded', 'false');
     document.body.classList.remove('nav-open');
+    const stored = parseInt(document.body.dataset.navScroll || '0', 10);
+    document.body.style.top = '';
+    delete document.body.dataset.navScroll;
+    window.scrollTo(0, isNaN(stored) ? 0 : stored);
     document.removeEventListener('keydown', trapFocus);
     document.removeEventListener('keydown', escToClose);
     if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();


### PR DESCRIPTION
## Summary
- ensure the mobile drawer renders with a solid backdrop instead of the page content
- prevent body scroll while the navigation drawer is open and preserve scroll position on close
- allow the drawer sheet to scroll independently when content is longer than the viewport

## Testing
- Manual verification in mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_690d3e4075e48322b05b6cf9bc32de2a